### PR TITLE
Change Apollo Server context configurations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ const app = express();
 const server = new ApolloServer({
   ...schema,
   resolvers,
-  context: async ({ req, res }) => ({ models, user: req.user }),
+  context: async ({ req, res }) => ({ models, user: req.user || null }),
   instrospection: true,
   playground: true,
   tracing: true,


### PR DESCRIPTION
Fix error that didn't let using the currentUser query from back-end and always returned cached data: 
```
const server = new ApolloServer({
    ...
    context: async ({ req, res }) => ({ models, user: req.user || null }),
    ...
});
```
The error was that passport return a _false_ and GraphQL didn't recognize it as a null value for matching with the currentUser query.

Modified line: ({ models, user: req.user **|| null** }),

